### PR TITLE
Disable the { strip } option from doT

### DIFF
--- a/lib/svg_image.coffee
+++ b/lib/svg_image.coffee
@@ -61,7 +61,7 @@ class SVGImage
     @_checkSVG(doc)
     doc = new xmldom.XMLSerializer().serializeToString(doc)
 
-    @template =  doT.template(doc)
+    @template =  doT.template(doc, _.extend({ strip: false }, doT.templateSettings))
 
   _checkSVG: (doc) ->
     if !(Object.keys(@colors).length > 0)


### PR DESCRIPTION
It was ruining my SVG output.

I had an SVG with a `\n` character inside a `points` attribute of a `<polygon>`, and doT removed the `\n`, joining two points and ruining my beautiful shape!

Adding the `{strip:false}` option fixes this, but I had do use `_.merge` for some reason, or the doT output would completely change.
