### PR TITLE
Pin dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,22 +26,22 @@
   },
   "homepage": "https://github.com/Pavliko/postcss-svg#readme",
   "dependencies": {
-    "color": "^0.10.1",
-    "dot": "^1.0.3",
-    "evil-icons": "^1.7.8",
-    "lodash": "^3.10.1",
-    "postcss": "^5.0.10",
-    "svgo": "^0.5.6",
-    "xmldom": "^0.1.19"
+    "color": "0.10.1",
+    "dot": "1.0.3",
+    "evil-icons": "1.7.8",
+    "lodash": "3.10.1",
+    "postcss": "5.0.10",
+    "svgo": "0.5.6",
+    "xmldom": "0.1.19"
   },
   "devDependencies": {
-    "autoprefixer-core": "^6.0.1",
-    "gulp": "^3.9.0",
-    "gulp-coffee": "^2.3.1",
-    "gulp-livereload": "^3.8.1",
-    "gulp-load-plugins": "^1.1.0",
-    "gulp-postcss": "^6.0.1",
-    "gulp-rename": "^1.2.2",
+    "autoprefixer-core": "6.0.1",
+    "gulp": "3.9.0",
+    "gulp-coffee": "2.3.1",
+    "gulp-livereload": "3.8.1",
+    "gulp-load-plugins": "1.1.0",
+    "gulp-postcss": "6.0.1",
+    "gulp-rename": "1.2.2",
     "open": "0.0.5"
   }
 }


### PR DESCRIPTION
This helps against things suddenly exploding in your face, such as our deploys today because xmldom slipped a not-so-backwards-compatible update in a patch version. Who can blame them, it's impossible to know all the different ways people are using your project and what effects a minor change might have, and how that might break things in subtle or not so subtle ways for them.

Long story short, let's pin dependencies so any change is explicit & tested, and our builds and deploys are reproducible.

See https://github.com/Pavliko/postcss-svg/issues/25
