### PR TITLE
Fix init cache position

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -9,9 +9,9 @@ module.exports = postcss.plugin "postcss-svg", (options = {}) ->
   silent = if _.isBoolean(options.silent) then options.silent else true
   silent = false if options.debug
 
-  (style, result) ->
-    SVGCache.init(options)
+  SVGCache.init(options)
 
+  (style, result) ->
     style.walkDecls /^background|^filter|^content|image$/, (decl) ->
       return unless decl.value
       while matches = SVGRegExp.exec(decl.value.replace(/'/g, '"'))


### PR DESCRIPTION
When you use postcss with browserify + cssmodules, every file compilation run `SVGCache.init` and it take much time (70 svg - 200ms every file).
